### PR TITLE
Add #171

### DIFF
--- a/src/Platform_Core/org/lobobrowser/gui/FramePanel.java
+++ b/src/Platform_Core/org/lobobrowser/gui/FramePanel.java
@@ -1332,7 +1332,10 @@ public class FramePanel extends JPanel implements NavigatorFrame {
   public void manageRequests(final Object initiator) {
     requestManager.manageRequests((JComponent) initiator);
   }
-
+  
+  public int[] getAcceptRejectData() {
+    return requestManager.getAcceptRejectData();
+  }
   public void allowAllFirstPartyRequests() {
     requestManager.allowAllFirstPartyRequests();
   }

--- a/src/Platform_Core/org/lobobrowser/security/PermissionTable.java
+++ b/src/Platform_Core/org/lobobrowser/security/PermissionTable.java
@@ -1,13 +1,17 @@
 package org.lobobrowser.security;
 
+import java.awt.BorderLayout;
+import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.GridLayout;
 import java.awt.Insets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
@@ -22,7 +26,7 @@ import org.lobobrowser.ua.UserAgentContext.RequestKind;
 
 public class PermissionTable {
 
-  public static JComponent makeTable(final PermissionSystem system, final String[] columnNames, final String[][] requestData) {
+  public static JComponent makeTable(final PermissionSystem system, final String[] columnNames, final String[][] requestData, final int[] acceptRejectData) {
     final List<PermissionCellButton> buttons = new LinkedList<>();
     final ChangeListener listener = () -> {
       buttons.stream().forEach(b -> b.update());
@@ -46,7 +50,7 @@ public class PermissionTable {
     });
     tabPane.setFocusable(false);
     system.getBoards().stream().forEachOrdered(board -> {
-      final JPanel grid = makeBoardView(board, columnNames, requestData, buttons, listener);
+      final JPanel grid = makeBoardView(board, columnNames, requestData, acceptRejectData, buttons, listener);
       tabPane.add(board.hostPattern, grid);
     });
     tabPane.setSelectedIndex(tabPane.getTabCount() - 1);
@@ -54,7 +58,7 @@ public class PermissionTable {
   }
 
   private static JPanel makeBoardView(final PermissionBoard board, final String[] columnNames, final String[][] requestData,
-      final List<PermissionCellButton> buttons, final ChangeListener listener) {
+      final int[] acceptRejectData, final List<PermissionCellButton> buttons, final ChangeListener listener) {
     final JPanel grid = new JPanel(new GridBagLayout());
     final GridBagConstraints gbc = new GridBagConstraints();
     gbc.gridx = 0;
@@ -75,8 +79,19 @@ public class PermissionTable {
         addRowToGrid(grid, gbc, row, requestData[i], listener, buttons);
       }
     }
-    final JPanel wrapGrid = new JPanel();
-    wrapGrid.add(grid);
+   
+    final JPanel requestsInformation = new JPanel();
+    final JLabel acceptedRequests = new JLabel();
+    acceptedRequests.setText("Accepted: " + acceptRejectData[0]);
+    final JLabel rejectedRequests = new JLabel();
+    rejectedRequests.setText("Rejected: " + acceptRejectData[1]);
+    
+    requestsInformation.add(acceptedRequests);
+    requestsInformation.add(rejectedRequests);
+    
+    final JPanel wrapGrid = new JPanel(new GridLayout(0, 1));
+    wrapGrid.add(grid, "Center");
+    wrapGrid.add(requestsInformation, "South");
     wrapGrid.setBorder(new EmptyBorder(16, 16, 16, 16));
     return wrapGrid;
   }
@@ -98,5 +113,6 @@ public class PermissionTable {
       grid.add(button, gbc);
       buttons.add(button);
     }
+    
   }
 }

--- a/src/Platform_Core/org/lobobrowser/security/RequestManager.java
+++ b/src/Platform_Core/org/lobobrowser/security/RequestManager.java
@@ -45,7 +45,8 @@ public final class RequestManager {
   /**
    * Constructor for the RequestManager class
    * 
-   * @param frame navigation frame that the user will interact with
+   * @param frame
+   *          navigation frame that the user will interact with
    */
   public RequestManager(final NavigatorFrame frame) {
     this.frame = frame;
@@ -83,7 +84,8 @@ public final class RequestManager {
    * updateCounter: helper function to update the counter for a given request
    * within the hostToCounterMap
    * 
-   * @param request that has been made by the user
+   * @param request
+   *          that has been made by the user
    */
   private synchronized void updateCounter(final Request request) {
     final String host = request.url.getHost().toLowerCase();
@@ -94,8 +96,10 @@ public final class RequestManager {
    * updateCounter: updates the counter for a given host based on the kind of
    * request that was queried
    * 
-   * @param String specified host from URL bar
-   * @param {@link org.lobobrowser.ua.UserAgentContext.RequestKind}
+   * @param String
+   *          specified host from URL bar
+   * @param {@link
+   *          org.lobobrowser.ua.UserAgentContext.RequestKind}
    */
   private synchronized void updateCounter(final String host, final RequestKind kind) {
     ensureHostInCounter(host);
@@ -106,7 +110,8 @@ public final class RequestManager {
    * ensureHostInCounter: ensures that the given URL has been stored with it's
    * given request counters for it's returned types
    * 
-   * @param String host from the URL bar
+   * @param String
+   *          host from the URL bar
    */
   private void ensureHostInCounter(final String host) {
     if (!hostToCounterMap.containsKey(host)) {
@@ -128,7 +133,8 @@ public final class RequestManager {
   /**
    * getFrameHost: returns a specified hostname
    * 
-   * @return String the requested hostname
+   * @return String 
+   *          the requested hostname
    */
   private Optional<String> getFrameHost() {
     return getFrameNavigationEntry().map(e -> {
@@ -149,7 +155,9 @@ public final class RequestManager {
   /**
    * rewriteRequest: will rewrite any request that has been made by a user
    * 
-   * @param request {@link org.lobobrowser.ua.UserAgentContext.Request} Request object that was originally intended to be made
+   * @param request
+   *          {@link org.lobobrowser.ua.UserAgentContext.Request} Request object
+   *          that was originally intended to be made
    * @return newly created request object
    */
   private Request rewriteRequest(final Request request) {
@@ -171,7 +179,8 @@ public final class RequestManager {
    * permitted 2) If request is permitted update associated fields with request
    * parameters 3) Else update request has been rejected
    * 
-   * @param request that has been made by the user
+   * @param request
+   *          that has been made by the user
    * @return boolean request has either been permitted or rejected
    */
   public boolean isRequestPermitted(final Request request) {
@@ -236,7 +245,8 @@ public final class RequestManager {
    * getRequestKindNames: returns a list of the types of requests that can be
    * made {@link org.lobobrowser.ua.UserAgentContext.RequestKind}
    * 
-   * @return Stream<String> stream of shortened name for the given request
+   * @return Stream<String> 
+   *          stream of shortened name for the given request
    */
   private static Stream<String> getRequestKindNames() {
     return Arrays.stream(RequestKind.values()).map(kind -> kind.shortName);
@@ -245,7 +255,8 @@ public final class RequestManager {
   /**
    * reset: Resets all request information each time a new URL name is entered.
    * 
-   * @param URL current URL entered by the user
+   * @param URL
+   *          current URL entered by the user
    */
   public synchronized void reset(final URL frameUrl) {
     hostToCounterMap = new HashMap<>();
@@ -261,7 +272,8 @@ public final class RequestManager {
    * manageRequests: sets up the RequestManager component this is called from
    * {@link org.lobobrowser.gui.FramePanel}
    * 
-   * @param initiatorComponent the top-level swing container
+   * @param initiatorComponent
+   *          the top-level swing container
    */
   public void manageRequests(final JComponent initiatorComponent) {
     // permissionSystemOpt.ifPresent(r -> r.dump());
@@ -274,7 +286,8 @@ public final class RequestManager {
    * getRequestData: called by {@link org.lobobrowser.security.RequestManager}
    * and populates the RequestManager GUI with a requests return counter values.
    * 
-   * @return String[][] a two dimensional array of a requests counter values
+   * @return String[][] 
+   *          a two dimensional array of a requests counter values
    */
   private synchronized String[][] getRequestData() {
     // hostToCounterMap.keySet().stream().forEach(System.out::println);
@@ -294,7 +307,7 @@ public final class RequestManager {
    * 
    * @return int[] an integer array sub two values 0 for accept 1 for reject
    */
-  private synchronized int[] getAcceptRejectData() {
+  public synchronized int[] getAcceptRejectData() {
     int[] temp = new int[2];
     temp[0] = acceptedRequests;
     temp[1] = rejectedRequests;
@@ -306,7 +319,8 @@ public final class RequestManager {
    * types such as: img CSS Cookie JS Frame XHR Referrer Unsecured HTTP
    * {@link org.lobobrowser.ua.UserAgentContext.RequestKind}
    * 
-   * @return String[] list of request type names
+   * @return String[] 
+   *          list of request type names
    */
   private static String[] getColumnNames() {
     final List<String> kindNames = getRequestKindNames().collect(Collectors.toList());

--- a/src/Platform_Core/org/lobobrowser/security/RequestManager.java
+++ b/src/Platform_Core/org/lobobrowser/security/RequestManager.java
@@ -11,7 +11,6 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -46,8 +45,7 @@ public final class RequestManager {
   /**
    * Constructor for the RequestManager class
    * 
-   * @param frame
-   *          navigation frame that the user will interact with
+   * @param frame navigation frame that the user will interact with
    */
   public RequestManager(final NavigatorFrame frame) {
     this.frame = frame;
@@ -85,8 +83,7 @@ public final class RequestManager {
    * updateCounter: helper function to update the counter for a given request
    * within the hostToCounterMap
    * 
-   * @param request
-   *          that has been made by the user
+   * @param request that has been made by the user
    */
   private synchronized void updateCounter(final Request request) {
     final String host = request.url.getHost().toLowerCase();
@@ -97,10 +94,8 @@ public final class RequestManager {
    * updateCounter: updates the counter for a given host based on the kind of
    * request that was queried
    * 
-   * @param String
-   *          specified host from URL bar
-   * @param {@link
-   *          org.lobobrowser.ua.UserAgentContext.RequestKind}
+   * @param String specified host from URL bar
+   * @param {@link org.lobobrowser.ua.UserAgentContext.RequestKind}
    */
   private synchronized void updateCounter(final String host, final RequestKind kind) {
     ensureHostInCounter(host);
@@ -111,8 +106,7 @@ public final class RequestManager {
    * ensureHostInCounter: ensures that the given URL has been stored with it's
    * given request counters for it's returned types
    * 
-   * @param String
-   *          host from the URL bar
+   * @param String host from the URL bar
    */
   private void ensureHostInCounter(final String host) {
     if (!hostToCounterMap.containsKey(host)) {
@@ -155,8 +149,7 @@ public final class RequestManager {
   /**
    * rewriteRequest: will rewrite any request that has been made by a user
    * 
-   * @param request
-   *          Request object that was originally intended to be made
+   * @param request {@link org.lobobrowser.ua.UserAgentContext.Request} Request object that was originally intended to be made
    * @return newly created request object
    */
   private Request rewriteRequest(final Request request) {
@@ -178,7 +171,7 @@ public final class RequestManager {
    * permitted 2) If request is permitted update associated fields with request
    * parameters 3) Else update request has been rejected
    * 
-   * @param request
+   * @param request that has been made by the user
    * @return boolean request has either been permitted or rejected
    */
   public boolean isRequestPermitted(final Request request) {
@@ -252,8 +245,7 @@ public final class RequestManager {
   /**
    * reset: Resets all request information each time a new URL name is entered.
    * 
-   * @param URL
-   *          the current URL entered by the user
+   * @param URL current URL entered by the user
    */
   public synchronized void reset(final URL frameUrl) {
     hostToCounterMap = new HashMap<>();
@@ -269,9 +261,7 @@ public final class RequestManager {
    * manageRequests: sets up the RequestManager component this is called from
    * {@link org.lobobrowser.gui.FramePanel}
    * 
-   * @param initiatorComponent
-   *          the top-level swing container
-   * @return void
+   * @param initiatorComponent the top-level swing container
    */
   public void manageRequests(final JComponent initiatorComponent) {
     // permissionSystemOpt.ifPresent(r -> r.dump());

--- a/src/Platform_Public_API/org/lobobrowser/ua/NavigatorFrame.java
+++ b/src/Platform_Public_API/org/lobobrowser/ua/NavigatorFrame.java
@@ -411,5 +411,8 @@ public interface NavigatorFrame {
 
   public void manageRequests(Object initiator);
 
+  
+  public int[] getAcceptRejectData();
+  
   public void allowAllFirstPartyRequests();
 }

--- a/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
+++ b/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
@@ -409,6 +409,7 @@ public class ComponentSource implements NavigatorWindowListener {
     if (this.window.getTopFrame() == event.getNavigatorFrame()) {
       this.clearState();
       this.actionPool.updateEnabling();
+      
     }
   }
 
@@ -431,6 +432,8 @@ public class ComponentSource implements NavigatorWindowListener {
     this.statusMessage = null;
     this.defaultStatusMessage = null;
     this.statusMessageComponent.setText("");
+    /** Emplace here until finding a better solution **/
+    processAcceptedRejected();
   }
 
   public void progressUpdated(final NavigatorProgressEvent event) {
@@ -443,8 +446,15 @@ public class ComponentSource implements NavigatorWindowListener {
       }
     }
     this.statusMessageComponent.setText(ClientletRequestHandler.getProgressMessage(event.getProgressType(), event.getUrl()));
+  
   }
 
+  public void processAcceptedRejected() {
+    int[] acceptRejectData = window.getTopFrame().getAcceptRejectData();
+    if (reqManagerButton instanceof JButton) {
+      reqManagerButton.setText("Req Mgr" + " " + "A: " + acceptRejectData[0] +  " D: " + acceptRejectData[1]);
+    }
+  }
   private String statusMessage;
 
   public void statusUpdated(final NavigatorWindowEvent event) {


### PR DESCRIPTION
Add #171: Support for accepted and rejected requests. Currently set to simple counters, serialized into an array that is passed to the Request Manager GUI. Then displayed as text objects.