### PR TITLE
Explicitly set UTF-8 encoding for Java source files.

### DIFF
--- a/src/HTML_Renderer/build.xml
+++ b/src/HTML_Renderer/build.xml
@@ -72,7 +72,7 @@
     </target>
     <target depends="init" name="build-project">
         <echo message="${ant.project.name}: ${ant.file}"/>
-        <javac debug="true" debuglevel="${debuglevel}" destdir="bin" includeantruntime="false" source="${source}" target="${target}">
+        <javac debug="true" debuglevel="${debuglevel}" destdir="bin" includeantruntime="false" source="${source}" target="${target}" encoding="UTF8">
             <src path="."/>
             <classpath refid="HTML_Renderer.classpath"/>
         </javac>


### PR DESCRIPTION
By default, Ant invokes javac with the system LC flags. This change
forces javac to always treat files as  UTF-8 encoded, regardless
of the local environment.i

Signed-off-by: Brian J Murray <bmurray7jhu@gmail.com>